### PR TITLE
Allows the forwarding of Content-* headers necessary to POST/JSON

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -37,8 +37,8 @@ $valid_requests = array(
 // identify request headers
 $request_headers = array( );
 foreach ( $_SERVER as $key => $value ) {
-	if ( in_array( substr( $key, 0, 5 ), array('HTTP_', 'CONTE') ) ) {
-		$headername = str_replace( '_', ' ', substr( $key, 5 ) );
+	if ( strpos($key, 'HTTP_') === 0  ||  strpos($key, 'CONTENT_') === 0 ) {
+		$headername = str_replace( '_', ' ', str_replace('HTTP_', '', $key));
 		$headername = str_replace( ' ', '-', ucwords( strtolower( $headername ) ) );
 		if ( !in_array( $headername, array( 'Host', 'X-Proxy-Url' ) ) ) {
 			$request_headers[] = "$headername: $value";

--- a/proxy.php
+++ b/proxy.php
@@ -3,7 +3,7 @@
 /**
  * AJAX Cross Domain (PHP) Proxy 0.8
  *    by Iacovos Constantinou (http://www.iacons.net)
- * 
+ *
  * Released under CC-GNU GPL
  */
 
@@ -37,7 +37,7 @@ $valid_requests = array(
 // identify request headers
 $request_headers = array( );
 foreach ( $_SERVER as $key => $value ) {
-	if ( substr( $key, 0, 5 ) == 'HTTP_' ) {
+	if ( in_array( substr( $key, 0, 5 ), array('HTTP_', 'CONTE') ) ) {
 		$headername = str_replace( '_', ' ', substr( $key, 5 ) );
 		$headername = str_replace( ' ', '-', ucwords( strtolower( $headername ) ) );
 		if ( !in_array( $headername, array( 'Host', 'X-Proxy-Url' ) ) ) {


### PR DESCRIPTION
krinklemail at gmail dot com - 2 years ago [0]
If requests to your PHP script send a header "Content-Type" or/ "Content-Length" it will, contrary to regular HTTP headers, not appear in $_SERVER as $_SERVER['HTTP_CONTENT_TYPE']. PHP removes these (per CGI/1.1 specification[1]) from the HTTP_ match group.

They are still accessible, but only if the request was a POST request. When it is, it'll be available as:
$_SERVER['CONTENT_LENGTH']
$_SERVER['CONTENT_TYPE']

[0] http://php.net/manual/en/reserved.variables.server.php
[1] https://www.ietf.org/rfc/rfc3875