### PR TITLE
Pass content-type to proxy

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -46,6 +46,10 @@ foreach ( $_SERVER as $key => $value ) {
 	}
 }
 
+if (isset($_SERVER["CONTENT_TYPE"])) {
+	$request_headers[] = 'Content-Type: ' . $_SERVER["CONTENT_TYPE"];
+}
+
 // identify request method, url and params
 $request_method = $_SERVER['REQUEST_METHOD'];
 if ( 'GET' == $request_method ) {


### PR DESCRIPTION
Currently the content-type, as available in `$_SERVER['CONTENT_TYPE']` is not passed to the target URL. This pull request solves this by adding the required header.