### PR TITLE
Add option to suppress Expect: 100-continue header

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -137,6 +137,7 @@ if ($request_method == 'GET' && count($request_params) > 0 && (!array_key_exists
 
 // let the request begin
 $ch = curl_init($request_url);
+array_push($request_headers, 'Expect:'); // Many hosts don't support 100-Expect
 curl_setopt($ch, CURLOPT_HTTPHEADER, $request_headers);   // (re-)send headers
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);     // return response
 curl_setopt($ch, CURLOPT_HEADER, true);       // enabled response headers

--- a/proxy.php
+++ b/proxy.php
@@ -57,7 +57,7 @@ $curl_options = array(
 // identify request headers
 $request_headers = array( );
 foreach ($_SERVER as $key => $value) {
-    if (strpos($key, 'HTTP_') === 0  ||  strpos($key, 'CONTENT_') === 0) {
+    if (strpos($key, 'HTTP_') === 0 ) {
         $headername = str_replace('_', ' ', str_replace('HTTP_', '', $key));
         $headername = str_replace(' ', '-', ucwords(strtolower($headername)));
         if (!in_array($headername, array( 'Host', 'X-Proxy-Url' ))) {

--- a/proxy.php
+++ b/proxy.php
@@ -30,6 +30,13 @@ define('CSAJAX_FILTERS', true);
 define('CSAJAX_FILTER_DOMAIN', false);
 
 /**
+ * Enables or disables Expect: 100-continue header. Some webservers don't 
+ * handle this header correctly.
+ * Recommended value: false
+ */
+define('CSAJAX_SUPPRESS_EXPECT', false);
+
+/**
  * Set debugging to true to receive additional messages - really helpful on development
  */
 define('CSAJAX_DEBUG', false);
@@ -57,7 +64,7 @@ $curl_options = array(
 // identify request headers
 $request_headers = array( );
 foreach ($_SERVER as $key => $value) {
-    if (strpos($key, 'HTTP_') === 0 ) {
+    if (strpos($key, 'HTTP_') === 0  ||  strpos($key, 'CONTENT_') === 0) {
         $headername = str_replace('_', ' ', str_replace('HTTP_', '', $key));
         $headername = str_replace(' ', '-', ucwords(strtolower($headername)));
         if (!in_array($headername, array( 'Host', 'X-Proxy-Url' ))) {
@@ -137,7 +144,12 @@ if ($request_method == 'GET' && count($request_params) > 0 && (!array_key_exists
 
 // let the request begin
 $ch = curl_init($request_url);
-array_push($request_headers, 'Expect:'); // Many hosts don't support 100-Expect
+
+// Suppress Expect header
+if (CSAJAX_SUPPRESS_EXPECT) {
+    array_push($request_headers, 'Expect:'); 
+}
+
 curl_setopt($ch, CURLOPT_HTTPHEADER, $request_headers);   // (re-)send headers
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);     // return response
 curl_setopt($ch, CURLOPT_HEADER, true);       // enabled response headers


### PR DESCRIPTION
Hi there. Great little script. Thanks for it.

We've added a configuration option to suppress the `Expect: 100-continue` header which CURL adds automatically but which is [not handled correctly](https://curl.haxx.se/mail/archive-2005-06/0074.html) by some web servers. Would be grateful if you'd consider merging this into master.

Thanks!